### PR TITLE
Add child-row-{rowIndex} class to child rows

### DIFF
--- a/scripts/gridRow.jsx
+++ b/scripts/gridRow.jsx
@@ -126,7 +126,7 @@ class GridRow extends React.Component {
         let className = this.props.rowSettings && this.props.rowSettings.getBodyRowMetadataClass(this.props.data) || "standard-row";
 
         if (this.props.isChildRow) {
-            className = "child-row";
+            className = "child-row" + (!this.props.useGriddleStyles ?  ("-" +this.props.nestingLevel) : "");
         } else if (this.props.hasChildren) {
             className = this.props.showChildren ? this.props.parentRowExpandedClassName : this.props.parentRowCollapsedClassName;
         }


### PR DESCRIPTION
When having griddle styles turned off, every child row (tr) is assigned the class "child-row-{rowIndex}".
Useful to make the identation of child rows outside the griddle internal logic (by css rules)
