### PR TITLE
Griddle.jsx : column issues and extending filters

### DIFF
--- a/scripts/griddle.jsx
+++ b/scripts/griddle.jsx
@@ -129,11 +129,17 @@ var Griddle = React.createClass({
         uniqueIdentifier: React.PropTypes.string
     },
     defaultFilter: function(results, filter) {
+      var colMetadata = (that.columnSettings.columnMetadata || []).reduce(function(previous, current){
+        previous[current.columnName] = current;
+        return previous;
+      }, {});
+
       return _.filter(results,
       function(item) {
            var arr = deep.keys(item);
            for(var i = 0; i < arr.length; i++){
-              if ((deep.getAt(item, arr[i])||"").toString().toLowerCase().indexOf(filter.toLowerCase()) >= 0){
+              var toFilterableStringFn = colMetadata[arr[i]] && colMetadata[arr[i]].toFilterableString;
+              if ((toFilterableStringFn ? toFilterableStringFn(item[arr[i]], item, arr[i]) : (deep.getAt(item, arr[i])||"")).toString().toLowerCase().indexOf(filter.toLowerCase()) >= 0){
                return true;
               }
            }
@@ -141,11 +147,16 @@ var Griddle = React.createClass({
        });
     },
     filterByColumnFilters(columnFilters) {
-        var filteredResults = Object.keys(columnFilters).reduce(function (previous, current) {
+        var that = this;
+        var filteredResults = Object.keys(columnFilters).reduce(function (previous, current, index) {
             return _.filter(
                 previous,
                 function (item) {
-                    if (deep.getAt(item, current || "").toString().toLowerCase().indexOf(columnFilters[current].toLowerCase()) >= 0) {
+                    var currentColMetadata =  _.find(that.columnSettings.columnMetadata || [], function(cm){
+                      return cm.columnName == current;
+                    });
+                    var toFilterableStringFn = currentColMetadata && currentColMetadata.toFilterableString;
+                    if ((toFilterableStringFn ? toFilterableStringFn(item[current],item,current,index) :  deep.getAt(item, current || "")).toString().toLowerCase().indexOf(columnFilters[current].toLowerCase()) >= 0) {
                         return true;
                     }
 
@@ -406,7 +417,7 @@ var Griddle = React.createClass({
         this.verifyCustom();
 
         this.columnSettings = new ColumnProperties(
-            this.props.results.length > 0 ? deep.keys(this.props.results[0]) : [],
+            this.props.availableColumns || this.props.columns ||  (this.props.results.length > 0 ? deep.keys(this.props.results[0]) : []),
             this.props.columns,
             this.props.childrenColumnName,
             this.props.columnMetadata,
@@ -843,8 +854,11 @@ var Griddle = React.createClass({
 
         var meta = this.columnSettings.getMetadataColumns();
 
-        // Grab the column keys from the first results
-        keys = deep.keys(_.omit(results[0], meta));
+        /*
+        Previously, the list of columns was calculated by flattening the first item in the results, which was leading to
+        columns like User.Id , User.Name for nested JSONs like {Id: 1, User: {Id: 1, Name: "Some Username"}}
+        */
+        keys =  this.props.availableColumns || this.props.columns ? _.omit(this.props.availableColumns || this.props.columns, meta) : deep.keys(_.omit(results[0], meta));
 
         // sort keys by order
         keys = this.columnSettings.orderColumns(keys);


### PR DESCRIPTION
1. Fix available columns in settings. They were calculated by flattening the first row in results and when having nested objects in the data, additional columns are created (eg. User.Id, User.Name ). Now we can specify a list of available columns. If it is not specified, the columns are taken into consideration. Otherwise, the  columns are calculated the old way.
2. Fix column/ global filtering when rendering custom objects in the results JSON structure by provinding in columnMetadata an aditional toFilterableString helper
